### PR TITLE
deps: Update policies, kuberlr-kubectl image

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -47,6 +47,6 @@ annotations:
   catalog.cattle.io/type: cluster-tool
 dependencies:
   - name: policy-reporter
-    version: 3.3.1
+    version: 3.3.2
     repository: https://kyverno.github.io/policy-reporter
     condition: auditScanner.policyReporter

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -300,7 +300,7 @@ policy-reporter:
     image:
       registry: ghcr.io
       repository: kyverno/policy-reporter-ui
-      tag: 2.4.0
+      tag: 2.4.1
     views:
       logs: false
     logo:

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -294,7 +294,7 @@ policy-reporter:
   image:
     registry: ghcr.io
     repository: kyverno/policy-reporter
-    tag: 3.3.2
+    tag: 3.3.3
   ui:
     enabled: true
     image:

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -216,7 +216,7 @@ recommendedPolicies:
   userGroupPolicy:
     module:
       repository: "kubewarden/policies/user-group-psp"
-      tag: v1.0.2
+      tag: v1.0.3
     name: "do-not-run-as-root"
     settings:
       run_as_user:

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -198,7 +198,7 @@ recommendedPolicies:
   hostNamespacePolicy:
     module:
       repository: "kubewarden/policies/host-namespaces-psp"
-      tag: v1.0.3
+      tag: v1.1.0
     name: "no-host-namespace-sharing"
     settings:
       allow_host_ipc: false


### PR DESCRIPTION


Automatic update of dependencies: policies and kuberlr-kubectl image
This PR has been created by automation.

NOTE: REMEMBER TO SQUASH MERGE

Update policies:
- [ ] I have checked that the kubewarden-defaults values
  `recommendedPolicies.*.settings` are up to date
- [ ] I have updated charts/kubewarden-defaults/questions.yaml from
  those of the policies


---



<Actions>
    <action id="3acb135c504c2ae8359d15979baded28872b711ca5da31bcb08200dfa9e1a7a5">
        <h3>Update charts with new policies, policy-reporter and kubectl versions</h3>
        <details id="e7e3eaaef2c4b0db1427640a7bb23b6fbaabacb6b1ecb221f6dcedc929852c3c">
            <summary>Update ghcr.io/kyverno/policy-reporter image tag</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.policy-reporter.image.tag&#34; updated from &#34;3.3.2&#34; to &#34;3.3.3&#34;, in file &#34;charts/kubewarden-controller/values.yaml&#34;</p>
        </details>
        <details id="cd4ecb4a10a59e4e4cfd8b16d8b3eba88caaf32a5c10bf3258f12023a2b2bed1">
            <summary>Update ghcr.io/kubewarden/policies/host-namespaces-psp image tag</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.recommendedPolicies.hostNamespacePolicy.module.tag&#34; updated from &#34;v1.0.3&#34; to &#34;v1.1.0&#34;, in file &#34;charts/kubewarden-defaults/values.yaml&#34;</p>
        </details>
        <details id="19fee76b1911738ce58ce4fcdd914a82dc3efadf09d3a6d5d7e54e0100587053">
            <summary>Update ghcr.io/kubewarden/policies/user-group-psp image tag</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.recommendedPolicies.userGroupPolicy.module.tag&#34; updated from &#34;v1.0.2&#34; to &#34;v1.0.3&#34;, in file &#34;charts/kubewarden-defaults/values.yaml&#34;</p>
        </details>
        <details id="abd4411bd663e6a60429554a53ac50e3f5390c6c7320a30b1c7a4989671ba4bf">
            <summary>Update ghcr.io/kyverno/policy-reporter-ui image tag</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.policy-reporter.ui.image.tag&#34; updated from &#34;2.4.0&#34; to &#34;2.4.1&#34;, in file &#34;charts/kubewarden-controller/values.yaml&#34;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

