### PR TITLE
Helm chart minor release

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -35,7 +35,7 @@ annotations:
   catalog.cattle.io/display-name: Kubewarden # Only for Charts with custom UI
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
-  catalog.cattle.io/auto-install: kubewarden-crds=1.19.0
+  catalog.cattle.io/auto-install: kubewarden-crds=1.20.0-rc1
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
   # The following two will create a UI warning if the request is not available in cluster
   # Assume the most standard setup for your chart. These can be strings with amounts, ie 64Mi or 2Gi are both valid.

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.5.0
+version: 5.6.0-rc1
 # This is the version of Kubewarden stack
 appVersion: v1.27.0
 annotations:

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.19.0
+version: 1.20.0-rc1
 # This is the version of Kubewarden stack
 appVersion: v1.27.0
 annotations:

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -35,7 +35,7 @@ annotations:
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
-  catalog.cattle.io/auto-install: kubewarden-crds=1.19.0
+  catalog.cattle.io/auto-install: kubewarden-crds=1.20.0-rc1
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.5.0
+version: 3.6.0-rc1
 # This is the version of Kubewarden stack
 appVersion: v1.27.0
 annotations:


### PR DESCRIPTION


Automatic Helm chart minor update.
This PR has been created by the automation used to automatically update the Helm charts when some Kubewarden component is released

REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!


---



<Actions>
    <action id="d3b0c8fba35daecfc0bc391032d3dbe8668c68d7cc6988b2c2924c447c94abde">
        <h3>Update Kubewarden chart versions</h3>
        <details id="4c89403fab82c7708535f888ac0d486c03cb68f1f16cf05f96d49fc696ba680d">
            <summary>Update kubewarden-controller auto-install annotation</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.annotations.&#39;catalog.cattle.io/auto-install&#39;&#34; updated from &#34;kubewarden-crds=1.19.0&#34; to &#34;kubewarden-crds=1.20.0-rc1&#34;, in file &#34;charts/kubewarden-controller/Chart.yaml&#34;</p>
        </details>
        <details id="f5bb4c08de7836027e2fe84ac05c5f339df1ac889a1ff75665ff0679ba0041ed">
            <summary>Update kubewarden-crds version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.version&#34; updated from &#34;1.19.0&#34; to &#34;1.20.0-rc1&#34;, in file &#34;charts/kubewarden-crds/Chart.yaml&#34;</p>
        </details>
        <details id="757e7910f2d60cf00ee6cf34ead32fcfe62c8863c9579a2d4cdba78aa1123e8c">
            <summary>Bump defaults chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.version&#34; updated from &#34;3.5.0&#34; to &#34;3.6.0-rc1&#34;, in file &#34;charts/kubewarden-defaults/Chart.yaml&#34;</p>
        </details>
        <details id="a748cca550a82f2168668e9e92647b52ae040547a062e4de4bb75d492423a6d5">
            <summary>Bump controller chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.version&#34; updated from &#34;5.5.0&#34; to &#34;5.6.0-rc1&#34;, in file &#34;charts/kubewarden-controller/Chart.yaml&#34;</p>
        </details>
        <details id="c6634e7c4a01a9706beb4946abc8a4d59bf2f0d5a7ff364e4e0916d6b13b1385">
            <summary>Update kubewarden-defautls auto-install annotation</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.annotations.&#39;catalog.cattle.io/auto-install&#39;&#34; updated from &#34;kubewarden-crds=1.19.0&#34; to &#34;kubewarden-crds=1.20.0-rc1&#34;, in file &#34;charts/kubewarden-defaults/Chart.yaml&#34;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

